### PR TITLE
Added aarch64 build and more flexible build infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,23 @@ debian/.debhelper/*
 debian/tmp/*
 debian/nnstreamer/*
 debian/nnstreamer-dev/*
+debian/nnstreamer-caffe2/
+debian/nnstreamer-configuration/
+debian/nnstreamer-core/
+debian/nnstreamer-datarepo/
+debian/nnstreamer-dev-internal/
+debian/nnstreamer-edgetpu/
+debian/nnstreamer-misc/
+debian/nnstreamer-onnxruntime/
+debian/nnstreamer-openvino/
+debian/nnstreamer-pytorch/
+debian/nnstreamer-single-dev-internal/
+debian/nnstreamer-single-dev/
+debian/nnstreamer-single/
+debian/nnstreamer-tensorflow/
+debian/nnstreamer-tensorflow2-lite/
+debian/nnstreamer-test-dev/
+debian/nnstreamer-util/
 
 # Visual Studio & csapi
 *.exe

--- a/Documentation/getting-started-eyepop.md
+++ b/Documentation/getting-started-eyepop.md
@@ -1,0 +1,138 @@
+---
+title: EyePop
+...
+
+# Installing NNStreamer for EyePop development
+
+These instructions supplement the docs for installing the nnstreamer package for Ubuntu:
+* [With an existing .deb package](./getting-started-ubuntu-ppa.md)
+* [By building a .deb package locally](./getting-started-ubuntu-debuild.md)
+* [By building through meson/ninja](./getting-started-meson-build.md)
+
+See those docs for more details about `nnstreamer` internals.
+
+Currently supported EyePop platforms:
+* Ubuntu 22.04 on `amd64` (fully supported)
+* Ubuntu 22.04 on `aarch64` (TensorFlow Lite only)
+
+## Development Environment Setup
+
+For preexisting Docker images with all dependencies installed, see the
+[Docker setup instructions][docker-setup]. The corresponding Dockerfiles can be found
+[here][dockerfiles].
+
+To develop on your host machine, install the following required packages through your system package
+manager (instructions provided for `apt`). For EyePop-specific dependencies, add the EyePop package
+repo to your sources list before proceeding:
+
+```sh
+sudo echo "deb [trusted=yes] http://repo.dev.eyepop.xyz.s3.us-east-1.amazonaws.com/ stable main" \
+    | sudo tee /etc/apt/sources.list.d/eyepop.dev.list > /dev/null
+```
+
+`apt` instructions for installing everything below (leave out `eyepop-torchvision` on `aarch64`):
+
+```sh
+sudo apt install build-essential debhelper devscripts gcc9 meson ninja-build libglib2.0-dev \
+     libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libjson-glib-dev gstreamer1.0-tools \
+     gstreamer1.0-plugins-good libgtest-dev libopencv-dev flex bison python3-dev libpaho-mqtt-dev \
+     eyepop-tflite eyepop-torchvision
+```
+
+Build tools:
+* `bison`
+* `build-essential`
+* `debhelper`
+* `devscripts`
+* `gcc-9`
+* `flex`
+* `meson`
+* `ninja-build`
+* `python3-dev`
+
+Build dependencies:
+* `libglib2.0-dev`
+* `libgstreamer1.0-dev`
+* `libgstreamer-plugins-base1.0-dev`
+* `libgtest-dev`
+* `libjson-glib-dev`
+* `libopencv-dev`
+* `libpaho-mqtt-dev`
+
+Runtime dependencies:
+* `gstreamer1.0-tools`
+* `gstreamer1.0-plugins-good`
+
+EyePop-specific dependencies:
+* `eyepop-tflite`
+* `eyepop-torchvision` (amd64 only)
+
+## Build/install instructions
+
+### Developing locally
+
+`nnstreamer` uses `meson` to orchestrate the build. Use individual feature flags to control what you
+build for a particular platform.
+
+To build/test for Ubuntu 22.04 on `amd64` with support for ONNX, TensorFlow, and TensorFlow Lite:
+
+```sh
+meson -Dwerror=false -Donnxruntime-support=enabled -Dtf-support=enabled -Dcaffe2-support=disabled -Dpython3-support=disabled build/ -Denable-test=false
+
+ninja -C build
+
+ninja -C build test
+```
+
+To build/test for Ubuntu 22.04 on `aarch64` with support for TensorFlow Lite only:
+
+```sh
+meson -Dwerror=false -Donnxruntime-support=disabled -Dtf-support=disabled -Dcaffe2-support=disabled -Dpython3-support=disabled build/ -Denable-test=false
+
+ninja -C build
+
+ninja -C build test
+```
+
+### Building installable packages locally
+
+To build installable `.deb` packages locally, use `debuild`. Like `eyepop-ml-dev`, the EyePop build
+of `nnstreamer` uses platform identifiers to customize how packages get built.
+
+| Platform                       | CUDA Support? | Identifier                 |
+|--------------------------------|---------------|----------------------------|
+| Linux, `amd64`, Ubuntu 22.04   | yes           | `linux-amd64-jammy-cuda`   |
+| Linux, `amd64`, Ubuntu 22.04   | no            | `linux-amd64-jammy`        |
+| Linux, `aarch64`, Ubuntu 22.04 | no            | `linux-aarch64-jammy`      |
+
+To build for Ubuntu 22.04 on `amd64` with CUDA:
+
+```sh
+DEB_BUILD_OPTIONS="nocheck notest" debuild -b -us -uc -Plinux-amd64-jammy-cuda
+```
+
+To build for Ubuntu 22.04 on `amd64` without CUDA:
+
+```sh
+DEB_BUILD_OPTIONS="nocheck notest" debuild -b -us -uc -Plinux-amd64-jammy
+```
+
+To build for Ubuntu 22.04 on `aarch64`:
+
+```sh
+DEB_BUILD_OPTIONS="nocheck notest" debuild -b -us -uc -Plinux-aarch64-jammy
+```
+
+This will generate a series of `.deb` packages in the repo's parent directory. To install them with
+`apt`, run the following:
+
+```sh
+sudo apt install ../nnstreamer*.deb
+```
+
+### Notes on packaging strategy
+
+See `eyepop-ml-dev`'s README.
+
+[docker-setup]: https://app.gitbook.com/o/lp5TZAZIwu5jXdzZth9T/s/0fWYYHCrIOcShgRMiWhf/readme/howtos/running-as-docker-container
+[dockerfiles]: https://github.com/eyepop-ai/eyepop-docker-images

--- a/Documentation/hotdoc/sitemap.txt
+++ b/Documentation/hotdoc/sitemap.txt
@@ -7,6 +7,7 @@ index.md
 			getting-started-tizen.md
 			getting-started-ubuntu-debuild.md
 			getting-started-ubuntu-ppa.md
+			getting-started-eyepop.md
 		tutorials.md
 			tutorial1_playing_video.md
 			tutorial2_object_detection.md

--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ Note that this project has just started and many of the components are in design
 In [Component Description](Documentation/component-description.md) page, we describe nnstreamer components of the following three categories: data type definitions, gstreamer elements (plugins), and other misc components.
 
 ## Getting Started
+
+For EyePop-specific notes and instructions, press [here](Documentation/getting-started-eyepop.md).
+
 For more details, please access the following manuals.
 * For Linux-like systems such as Tizen, Debian, and Ubuntu, press [here](Documentation/getting-started.md).
 * For macOS systems, press [here](Documentation/getting-started-macos.md).

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+nnstreamer (2.4.1+1.0.0) jammy; urgency=medium
+
+  * Add support for aarch64 builds
+  * Add more flexible build infrastructure across debuild and Jenkins
+
+ -- Tyler Stevens <tyler@eyepop.ai>  Fri, 04 Oct 2024 16:42:30 -0700
+
 nnstreamer (2.4.1+nmu4) UNRELEASED; urgency=medium
 
   * tensor_filter ONNX: allow accleration

--- a/debian/control
+++ b/debian/control
@@ -9,8 +9,10 @@ Build-Depends: gcc-9 | gcc-8 | gcc-7 | gcc-6 | gcc-5 (>=5.4),
  libgtest-dev, libpng-dev, libopencv-dev, liborc-0.4-dev, flex, bison,
  python3, python3-dev, pkg-config,
  libpaho-mqtt-dev,
- libedgetpu1-std (>=12), libedgetpu-dev (>=12),
- openvino-dev, openvino-cpu-mkldnn [amd64],
+ libedgetpu1-std (>=12) <!linux-aarch64-jammy>,
+ libedgetpu-dev (>=12) <!linux-aarch64-jammy>,
+ openvino-dev <!linux-aarch64-jammy>,
+ openvino-cpu-mkldnn [amd64],
  nnfw-dev [amd64] | gcc
 Standards-Version: 3.9.6
 Homepage: https://github.com/nnstreamer/nnstreamer

--- a/debian/control.ubuntu.ppa
+++ b/debian/control.ubuntu.ppa
@@ -9,8 +9,10 @@ Build-Depends: gcc-9 | gcc-8 | gcc-7 | gcc-6 | gcc-5 (>=5.4),
  libgtest-dev, libpng-dev, libopencv-dev, liborc-0.4-dev, flex, bison,
  python3, python3-dev, pkg-config,
  libpaho-mqtt-dev,
- libedgetpu1-std (>=12), libedgetpu-dev (>=12),
- openvino-dev, openvino-cpu-mkldnn [amd64],
+ libedgetpu1-std (>=12) <!linux-aarch64-jammy>,
+ libedgetpu-dev (>=12) <!linux-aarch64-jammy>,
+ openvino-dev <!linux-aarch64-jammy>,
+ openvino-cpu-mkldnn [amd64],
  nnfw-dev [amd64] | gcc
 Standards-Version: 3.9.6
 Homepage: https://github.com/nnstreamer/nnstreamer

--- a/debian/rules
+++ b/debian/rules
@@ -52,7 +52,7 @@ endif
 
 %:
 ifeq ($(EYEPOP_PLATFORM),linux-aarch64-jammy)
-	dh $@ --parallel --without=nnstreamer-tensorflow --without=nnstreamer-edgetpu --without=nnstreamer-openvino --without=nnstreamer-onnxruntime --without=nnstreamer-test-dev
+	dh $@ --parallel --without=nnstreamer-tensorflow --without=nnstreamer-edgetpu --without=nnstreamer-openvino --without=nnstreamer-onnxruntime
 else
 	dh $@ --parallel
 endif
@@ -67,7 +67,7 @@ ifeq ($(EYEPOP_PLATFORM),linux-aarch64-jammy)
 	-Denable-edgetpu=false -Denable-openvino=false -Dgrpc-support=disabled -Dmqtt-support=enabled \
 	-Ddatarepo-support=enabled \
 	-Dtf-support=disabled -Donnxruntime-support=disabled \
-	-Denable-tizen=false -Denable-test=false -Dinstall-test=true -Dsubplugindir=/usr/lib/nnstreamer $(FLOAT16) ${BUILDDIR}
+	-Denable-tizen=false -Denable-test=true -Dinstall-test=true -Dsubplugindir=/usr/lib/nnstreamer $(FLOAT16) ${BUILDDIR}
 else ifeq ($(shell dpkg-vendor --derives-from Ubuntu && echo yes), yes)
 	meson --buildtype=plain --prefix=/usr --sysconfdir=/etc --libdir=lib/$(DEB_HOST_MULTIARCH) --bindir=lib/nnstreamer/bin --includedir=include \
 	-Denable-edgetpu=true -Denable-openvino=true -Dgrpc-support=disabled -Dmqtt-support=enabled \
@@ -88,7 +88,6 @@ ifeq ($(EYEPOP_PLATFORM),linux-aarch64-jammy)
 	rm -f debian/nnstreamer-edgetpu.install
 	rm -f debian/nnstreamer-openvino.install
 	rm -f debian/nnstreamer-onnxruntime.install
-	rm -f debian/nnstreamer-test-dev.install
 endif
 	# A few modules are not available in Ubuntu 22.04. Don't try to create them if not available.
 	if [ -f './build/ext/nnstreamer/tensor_filter/libnnstreamer_filter_nnfw.so' ]; then echo "NNFW exists" ; else rm -f debian/nnstreamer-nnfw.install; fi
@@ -112,7 +111,7 @@ override_dh_auto_install:
 	DESTDIR=$(CURDIR)/debian/tmp ninja -C ${BUILDDIR} install
 
 override_dh_gencontrol:
-	dh_gencontrol -- -v$(VERSION)~$(PLATFORM)
+	dh_gencontrol -- -v$(VERSION)~$(EYEPOP_PLATFORM)
 
 override_dh_install:
 	dh_install --sourcedir=debian/tmp --list-missing

--- a/debian/rules
+++ b/debian/rules
@@ -52,7 +52,7 @@ endif
 
 %:
 ifeq ($(EYEPOP_PLATFORM),linux-aarch64-jammy)
-	dh $@ --parallel --without=nnstreamer-tensorflow --without=nnstreamer-edgetpu --without=nnstreamer-openvino --without=nnstreamer-onnxruntime
+	dh $@ --parallel --package=nnstreamer --package=nnstreamer-core --package=nnstreamer-configuration --package=nnstreamer-single --package=nnstreamer-tensorflow2-lite --package=nnstreamer-dev --package=nnstreamer-dev-internal --package=nnstreamer-single-dev --package=nnstreamer-single-dev-internal --package=nnstreamer-test-dev --package=nnstreamer-util --package=nnstreamer-misc --package=nnstreamer-datarepo
 else
 	dh $@ --parallel
 endif
@@ -114,7 +114,11 @@ override_dh_gencontrol:
 	dh_gencontrol -- -v$(VERSION)~$(EYEPOP_PLATFORM)
 
 override_dh_install:
+ifeq ($(EYEPOP_PLATFORM),linux-aarch64-jammy)
+	dh_install --sourcedir=debian/tmp --list-missing --package=nnstreamer --package=nnstreamer-core --package=nnstreamer-configuration --package=nnstreamer-single --package=nnstreamer-tensorflow2-lite --package=nnstreamer-dev --package=nnstreamer-dev-internal --package=nnstreamer-single-dev --package=nnstreamer-single-dev-internal --package=nnstreamer-test-dev --package=nnstreamer-util --package=nnstreamer-misc --package=nnstreamer-datarepo
+else
 	dh_install --sourcedir=debian/tmp --list-missing
+endif
 # Add --fail-missing option after adding *.install files for all subpackages.
 
 

--- a/debian/rules
+++ b/debian/rules
@@ -27,6 +27,22 @@ export NNSTREAMER_CONVERTERS=${NNSTREAMER_BUILD_ROOT_PATH}/ext/nnstreamer/tensor
 export NNSTREAMER_TRAINERS=${NNSTREAMER_BUILD_ROOT_PATH}/ext/nnstreamer/tensor_trainer
 export PYTHONIOENCODING=utf-8
 
+VERSION:=$(shell dpkg-parsechangelog --show-field VERSION)
+
+EYEPOP_PLATFORM ?= linux-amd64-jammy-cuda
+
+ifeq ($(filter linux-amd64-jammy-cuda,$(DEB_BUILD_PROFILES)),linux-amd64-jammy-cuda)
+    EYEPOP_PLATFORM := linux-amd64-jammy-cuda
+endif
+
+ifeq ($(filter linux-amd64-jammy,$(DEB_BUILD_PROFILES)),linux-amd64-jammy)
+    EYEPOP_PLATFORM := linux-amd64-jammy
+endif
+
+ifeq ($(filter linux-aarch64-jammy,$(DEB_BUILD_PROFILES)),linux-aarch64-jammy)
+    EYEPOP_PLATFORM := linux-aarch64-jammy
+endif
+
 ifeq ($(DEB_BUILD_ARCH_CPU), arm)
 FLOAT16 := -Denable-float16=true
 endif
@@ -35,14 +51,24 @@ FLOAT16 := -Denable-float16=true
 endif
 
 %:
+ifeq ($(EYEPOP_PLATFORM),linux-aarch64-jammy)
+	dh $@ --parallel --without=nnstreamer-tensorflow --without=nnstreamer-edgetpu --without=nnstreamer-openvino --without=nnstreamer-onnxruntime --without=nnstreamer-test-dev
+else
 	dh $@ --parallel
+endif
 
 override_dh_auto_clean:
 	rm -rf ${BUILDDIR}
 
 override_dh_auto_configure:
 	mkdir -p ${BUILDDIR}
-ifeq ($(shell dpkg-vendor --derives-from Ubuntu && echo yes), yes)
+ifeq ($(EYEPOP_PLATFORM),linux-aarch64-jammy)
+	meson --buildtype=plain --prefix=/usr --sysconfdir=/etc --libdir=lib/$(DEB_HOST_MULTIARCH) --bindir=lib/nnstreamer/bin --includedir=include \
+	-Denable-edgetpu=false -Denable-openvino=false -Dgrpc-support=disabled -Dmqtt-support=enabled \
+	-Ddatarepo-support=enabled \
+	-Dtf-support=disabled -Donnxruntime-support=disabled \
+	-Denable-tizen=false -Denable-test=false -Dinstall-test=true -Dsubplugindir=/usr/lib/nnstreamer $(FLOAT16) ${BUILDDIR}
+else ifeq ($(shell dpkg-vendor --derives-from Ubuntu && echo yes), yes)
 	meson --buildtype=plain --prefix=/usr --sysconfdir=/etc --libdir=lib/$(DEB_HOST_MULTIARCH) --bindir=lib/nnstreamer/bin --includedir=include \
 	-Denable-edgetpu=true -Denable-openvino=true -Dgrpc-support=disabled -Dmqtt-support=enabled \
 	-Ddatarepo-support=enabled \
@@ -57,10 +83,17 @@ endif
 
 override_dh_auto_build:
 	ninja -C ${BUILDDIR}
-	# A few modules are not avaiable in Ubuntu 22.04. Don't try to create them if not available.
-	if [ -f './build/ext/nnstreamer/tensor_filter/libnnstreamer_filter_nnfw.so' ]; then echo "NNFW exists" ; else rm debian/nnstreamer-nnfw.install; fi
-	if [ -f './build/ext/nnstreamer/tensor_filter/libnnstreamer_filter_pytorch.so' ]; then echo "pytorch exists" ; else rm debian/nnstreamer-pytorch.install; fi
-	if [ -f './build/ext/nnstreamer/tensor_filter/libnnstreamer_filter_caffe2.so' ]; then echo "caffe2 exists" ; else rm debian/nnstreamer-caffe2.install; fi
+ifeq ($(EYEPOP_PLATFORM),linux-aarch64-jammy)
+	rm -f debian/nnstreamer-tensorflow.install
+	rm -f debian/nnstreamer-edgetpu.install
+	rm -f debian/nnstreamer-openvino.install
+	rm -f debian/nnstreamer-onnxruntime.install
+	rm -f debian/nnstreamer-test-dev.install
+endif
+	# A few modules are not available in Ubuntu 22.04. Don't try to create them if not available.
+	if [ -f './build/ext/nnstreamer/tensor_filter/libnnstreamer_filter_nnfw.so' ]; then echo "NNFW exists" ; else rm -f debian/nnstreamer-nnfw.install; fi
+	if [ -f './build/ext/nnstreamer/tensor_filter/libnnstreamer_filter_pytorch.so' ]; then echo "pytorch exists" ; else rm -f debian/nnstreamer-pytorch.install; fi
+	if [ -f './build/ext/nnstreamer/tensor_filter/libnnstreamer_filter_caffe2.so' ]; then echo "caffe2 exists" ; else rm -f debian/nnstreamer-caffe2.install; fi
 
 override_dh_auto_test:
 	./packaging/run_unittests_binaries.sh ./tests
@@ -77,6 +110,9 @@ endif
 
 override_dh_auto_install:
 	DESTDIR=$(CURDIR)/debian/tmp ninja -C ${BUILDDIR} install
+
+override_dh_gencontrol:
+	dh_gencontrol -- -v$(VERSION)~$(PLATFORM)
 
 override_dh_install:
 	dh_install --sourcedir=debian/tmp --list-missing

--- a/ext/nnstreamer/tensor_filter/meson.build
+++ b/ext/nnstreamer/tensor_filter/meson.build
@@ -347,8 +347,6 @@ else # no tflite2
   endif
 endif
 
-torchvision_dp = dependency('torchvision')
-
 if pytorch_support_is_available
   if cxx.get_id() != 'gcc'
     error('Pytorch headers (Array.h and reverse_iterator.h) require GCC for license issues. Use GCC or disable pytorch with -Dpytorch-support=disabled.')
@@ -357,7 +355,7 @@ if pytorch_support_is_available
     filter_sub_torch_sources = ['tensor_filter_pytorch.cc']
     # pytorch sources contain unused parameters
     ignore_unused_params = declare_dependency(compile_args: ['-Wno-unused-parameter'])
-    pytorch_support_deps += torchvision_dp
+    pytorch_support_deps += dependency('torchvision')
     pytorch_support_deps += ignore_unused_params
   endif
 

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -119,7 +119,7 @@ pipeline {
 
                         stage('Configure') {
                             steps {
-                                runShellCommand("sudo apt update && sudo apt install -y eyepop-tflite=3.0.0~linux-aarch64-jammy")
+                                runShellCommand("sudo apt update && sudo apt install -y eyepop-tflite=3.0.0~linux-aarch64-jammy libgtest-dev")
                                 runShellCommand("meson -Dwerror=false -Donnxruntime-support=disabled -Dtf-support=disabled -Dcaffe2-support=disabled -Dpython3-support=disabled build/ -Denable-test=false")
                             }
                         }

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -56,7 +56,7 @@ pipeline {
                     
                         stage('Test') {
                             steps {
-                                runShellCommand(sh "ninja -C build/ test")   
+                                runShellCommand("ninja -C build/ test")   
                             }
                         }
                         stage('Debian build') {
@@ -132,7 +132,7 @@ pipeline {
                     
                         stage('Test') {
                             steps {
-                                runShellCommand(sh "ninja -C build/ test")   
+                                runShellCommand("ninja -C build/ test")   
                             }
                         }
                         stage('Debian build') {

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -1,85 +1,196 @@
 pipeline {
 
-    agent {
-        label 'linux-amd64'
+    agent none
+
+    parameters {
+        booleanParam(name: 'ENABLE_DRY_RUN_COMPLETE', defaultValue: false, description: '"Runs" all stages (even conditional ones!) by printing out what would happen (ignores ENABLE_DEB_BUILD_WITHOUT_UPLOAD)')
+        booleanParam(name: 'ENABLE_DEB_BUILD_WITHOUT_UPLOAD', defaultValue: false, description: 'Enable the debian build (without uploading!) for test purposes')
+        string(name: 'GIT_BRANCH', defaultValue: '*/main', description: 'The name of the branch to check out. Remember to change the Jenkins pipeline configuration\'s "Branches to build"!')
     }
 
     stages {
-        stage('Clone sources') {
-            steps {
-                checkout scmGit(
-                    branches: [[name: '*/main']], 
-                    extensions: [
-                        submodule(parentCredentials: true,recursiveSubmodules: true, reference: ''),
-                        [$class: 'WipeWorkspace']
-                    ], 
-                    userRemoteConfigs: [
-                        [
-                            credentialsId: 'deploy_key_eyepop-nnstreamer_rsa', 
-                            url: 'git@github.com:eyepop-ai/eyepop-nnstreamer.git'
-                        ]
-                    ]
-                )
-                script {
-                    gitTag=sh(returnStdout: true, script: "git tag --contains | head -1").trim()
-                }   
-            }
-        }
+        stage('Parallel builds') {
+            parallel {
+                stage('Build for linux-amd64-jammy-cuda') {
+                    agent { label 'linux-amd64' }
+                    stages {
+                        stage('Clone sources') {
+                            steps {
+                                script {
+                                    if (params.ENABLE_DRY_RUN_COMPLETE) {
+                                        print "DRY RUN: Cloning sources from branch ${params.GIT_BRANCH}"
+                                    }
+                                    else {
+                                        checkout scmGit(
+                                            branches: [[name: "${GIT_BRANCH}"]], 
+                                            extensions: [
+                                                submodule(parentCredentials: true,recursiveSubmodules: true, reference: ''),
+                                                [$class: 'WipeWorkspace']
+                                            ], 
+                                            userRemoteConfigs: [
+                                                [
+                                                    credentialsId: 'deploy_key_eyepop-nnstreamer_rsa', 
+                                                    url: 'git@github.com:eyepop-ai/eyepop-nnstreamer.git'
+                                                ]
+                                            ]
+                                        )
+                                    }
+                                    
+                                    gitTag=sh(returnStdout: true, script: "git tag --contains | head -1").trim()
+                                }   
+                            }
+                        }
 
-        stage('Configure') {
-            steps {
-                sh "sudo apt update && sudo apt install -y eyepop-tflite=2.4.1 eyepop-torchvision=2.4.1"
-                sh "meson -Dwerror=false -Donnxruntime-support=enabled -Dtf-support=enabled -Dcaffe2-support=disabled -Dpython3-support=disabled build/ -Denable-test=false"
-            }
-        }
-    
-        stage('Build') {
-            steps {
-                sh "ninja -C build"        
-            }
-        }
-    
-        stage('Test') {
-            steps {
-                sh "ninja -C build/ test"        
-            }
-        }
-        stage('Debian build') {
-            when { 
-                 expression {
-                     return gitTag;
-                 }
-            }
-            steps {
-                sh 'uname -a && mkdir -p ./build.debian/linux_amd64/'
-                sh 'DEB_BUILD_OPTIONS="nocheck notest" debuild -us -uc'
-                sh 'mv ../nnstreamer*.deb ../nnstreamer*.ddeb ../nnstreamer*.dsc ../nnstreamer*.gz ../nnstreamer*.build ../nnstreamer*.buildinfo ../nnstreamer*.changes ./build.debian/linux_amd64/ && ls -la ./build.debian/linux_amd64/'
-            }
-        }
-        stage('Debian publish') {
-            when { 
-                 expression {
-                     return gitTag;
-                 }
-            }
-            steps {
-                withAWS(credentials:'repo-uploader', region: 'us-east-1') {
-                    script {
-                        sh "deb-s3 upload --bucket repo.dev.eyepop.xyz ./build.debian/linux_amd64/*.deb"
+                        stage('Configure') {
+                            steps {
+                                runShellCommand("sudo apt update && sudo apt install -y eyepop-tflite=3.0.0~linux-amd64-jammy-cuda eyepop-torchvision=3.0.0~linux-amd64-jammy-cuda")
+                                runShellCommand("meson -Dwerror=false -Donnxruntime-support=enabled -Dtf-support=enabled -Dcaffe2-support=disabled -Dpython3-support=disabled build/ -Denable-test=false")
+                            }
+                        }
+                    
+                        stage('Build') {
+                            steps {
+                                runShellCommand("ninja -C build")
+                            }
+                        }
+                    
+                        stage('Test') {
+                            steps {
+                                runShellCommand(sh "ninja -C build/ test")   
+                            }
+                        }
+                        stage('Debian build') {
+                            when { 
+                                expression {
+                                    return gitTag || params.ENABLE_DRY_RUN_COMPLETE || params.ENABLE_DEB_BUILD_WITHOUT_UPLOAD;
+                                }
+                            }
+                            steps {
+                                runShellCommand('uname -a && mkdir -p ./build.debian/linux_amd64/')
+                                runShellCommand('DEB_BUILD_OPTIONS="nocheck notest" debuild -us -uc =Plinux-amd64-jammy')
+                                runShellCommand('mv ../nnstreamer*.deb ../nnstreamer*.ddeb ../nnstreamer*.dsc ../nnstreamer*.gz ../nnstreamer*.build ../nnstreamer*.buildinfo ../nnstreamer*.changes ./build.debian/linux_amd64/ && ls -la ./build.debian/linux_amd64/')
+                            }
+                        }
+                        stage('Debian publish') {
+                            when { 
+                                expression {
+                                    return gitTag || params.ENABLE_DRY_RUN_COMPLETE;
+                                }
+                            }
+                            steps {
+                                withAWS(credentials:'repo-uploader', region: 'us-east-1') {
+                                    script {
+                                        runShellCommand("deb-s3 upload --bucket repo.dev.eyepop.xyz ./build.debian/linux_amd64/*.deb")
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                stage('Build for linux-aarch64-jammy') {
+                    agent { label 'linux-aarch64' }
+                    stages {
+                        stage('Clone sources') {
+                            steps {
+                                script {
+                                    if (params.ENABLE_DRY_RUN_COMPLETE) {
+                                        print "DRY RUN: Cloning sources from branch ${params.GIT_BRANCH}"
+                                    }
+                                    else {
+                                        checkout scmGit(
+                                            branches: [[name: "${GIT_BRANCH}"]], 
+                                            extensions: [
+                                                submodule(parentCredentials: true,recursiveSubmodules: true, reference: ''),
+                                                [$class: 'WipeWorkspace']
+                                            ], 
+                                            userRemoteConfigs: [
+                                                [
+                                                    credentialsId: 'deploy_key_eyepop-nnstreamer_rsa', 
+                                                    url: 'git@github.com:eyepop-ai/eyepop-nnstreamer.git'
+                                                ]
+                                            ]
+                                        )
+                                    }
+                                    
+                                    gitTag=sh(returnStdout: true, script: "git tag --contains | head -1").trim()
+                                }   
+                            }
+                        }
+
+                        stage('Configure') {
+                            steps {
+                                runShellCommand("sudo apt update && sudo apt install -y eyepop-tflite=3.0.0~linux-aarch64-jammy")
+                                runShellCommand("meson -Dwerror=false -Donnxruntime-support=disabled -Dtf-support=disabled -Dcaffe2-support=disabled -Dpython3-support=disabled build/ -Denable-test=false")
+                            }
+                        }
+                    
+                        stage('Build') {
+                            steps {
+                                runShellCommand("ninja -C build")
+                            }
+                        }
+                    
+                        stage('Test') {
+                            steps {
+                                runShellCommand(sh "ninja -C build/ test")   
+                            }
+                        }
+                        stage('Debian build') {
+                            when { 
+                                expression {
+                                    return gitTag || params.ENABLE_DRY_RUN_COMPLETE || params.ENABLE_DEB_BUILD_WITHOUT_UPLOAD;
+                                }
+                            }
+                            steps {
+                                runShellCommand('uname -a && mkdir -p ./build.debian/linux_aarch64/')
+                                runShellCommand('DEB_BUILD_OPTIONS="nocheck notest" debuild -us -uc =Plinux-aarch64-jammy')
+                                runShellCommand('mv ../nnstreamer*.deb ../nnstreamer*.ddeb ../nnstreamer*.dsc ../nnstreamer*.gz ../nnstreamer*.build ../nnstreamer*.buildinfo ../nnstreamer*.changes ./build.debian/linux_aarch64/ && ls -la ./build.debian/linux_aarch64/')
+                            }
+                        }
+                        stage('Debian publish') {
+                            when { 
+                                expression {
+                                    return gitTag || params.ENABLE_DRY_RUN_COMPLETE;
+                                }
+                            }
+                            steps {
+                                withAWS(credentials:'repo-uploader', region: 'us-east-1') {
+                                    script {
+                                        runShellCommand("deb-s3 upload --bucket repo.dev.eyepop.xyz ./build.debian/linux_aarch64/*.deb")
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }
         }
-   }
+    }
+
     post {
         success {
             script {
+                String baseDescription = "";
+                if (params.ENABLE_DRY_RUN_COMPLETE) {
+                    baseDescription = "DRY RUN: "
+                }
+                
                 if (gitTag) {
-                    currentBuild.description = "Release build version (gitTag="+gitTag+")"
+                    currentBuild.description = "${baseDescription}Release build version (gitTag="+gitTag+")"
                 } else {
-                    currentBuild.description = "Commit build version"
+                    currentBuild.description = "${baseDescription}Commit build version"
                 }
             }
         }
+    }
+}
+
+def runShellCommand(String command) {
+    if (params.ENABLE_DRY_RUN_COMPLETE) {
+        // In test mode, just echo the command
+        echo "DRY RUN: ${command}"
+    } else {
+        // In normal mode, execute the command
+        sh command
     }
 }

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -67,8 +67,8 @@ pipeline {
                             }
                             steps {
                                 runShellCommand('uname -a && mkdir -p ./build.debian/linux_amd64/')
-                                runShellCommand('DEB_BUILD_OPTIONS="nocheck notest" debuild -us -uc =Plinux-amd64-jammy')
-                                runShellCommand('mv ../nnstreamer*.deb ../nnstreamer*.ddeb ../nnstreamer*.dsc ../nnstreamer*.gz ../nnstreamer*.build ../nnstreamer*.buildinfo ../nnstreamer*.changes ./build.debian/linux_amd64/ && ls -la ./build.debian/linux_amd64/')
+                                runShellCommand('DEB_BUILD_OPTIONS="nocheck notest" debuild -b -us -uc -Plinux-amd64-jammy')
+                                runShellCommand('mv ../nnstreamer*.deb ../nnstreamer*.ddeb ./build.debian/linux_amd64/ && ls -la ./build.debian/linux_amd64/')
                             }
                         }
                         stage('Debian publish') {
@@ -143,8 +143,8 @@ pipeline {
                             }
                             steps {
                                 runShellCommand('uname -a && mkdir -p ./build.debian/linux_aarch64/')
-                                runShellCommand('DEB_BUILD_OPTIONS="nocheck notest" debuild -us -uc =Plinux-aarch64-jammy')
-                                runShellCommand('mv ../nnstreamer*.deb ../nnstreamer*.ddeb ../nnstreamer*.dsc ../nnstreamer*.gz ../nnstreamer*.build ../nnstreamer*.buildinfo ../nnstreamer*.changes ./build.debian/linux_aarch64/ && ls -la ./build.debian/linux_aarch64/')
+                                runShellCommand('DEB_BUILD_OPTIONS="nocheck notest" debuild -b -us -uc -Plinux-aarch64-jammy')
+                                runShellCommand('mv ../nnstreamer*.deb ../nnstreamer*.ddeb ./build.debian/linux_aarch64/ && ls -la ./build.debian/linux_aarch64/')
                             }
                         }
                         stage('Debian publish') {


### PR DESCRIPTION
Changes:

* Update version to 2.4.1+1.0.0
* Add platform identifier (`linux-amd64-jammy-cuda`, `linux-aarch64-jammy`, etc) for use in debian rules
* Modify output debian artifact names to include the platform identifier
* Update the Jenkins pipeline to simultaneously build on amd64 and aarch64
* Improve Jenkins pipeline ergonomics by adding parameters for dry run, forcing a (non-uploaded) debian build, and which Git branch to pull
* Fix issue where Meson searches for the torchvision dependency despite it being disabled
* Add debian output files to .gitignore