### PR TITLE
Remove platform ID from debian version 

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-nnstreamer (2.4.1+1.0.0) jammy; urgency=medium
+nnstreamer (2.4.1-1.0.0) jammy; urgency=medium
 
   * Add support for aarch64 builds
   * Add more flexible build infrastructure across debuild and Jenkins 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,9 +1,9 @@
 nnstreamer (2.4.1+1.0.0) jammy; urgency=medium
 
   * Add support for aarch64 builds
-  * Add more flexible build infrastructure across debuild and Jenkins
+  * Add more flexible build infrastructure across debuild and Jenkins 
 
- -- Tyler Stevens <tyler@eyepop.ai>  Fri, 04 Oct 2024 16:42:30 -0700
+ -- Tyler Stevens <tyler@eyepop.ai>  Wed, 09 Oct 2024 16:10:03 -0700
 
 nnstreamer (2.4.1+nmu4) UNRELEASED; urgency=medium
 

--- a/debian/rules
+++ b/debian/rules
@@ -110,9 +110,6 @@ endif
 override_dh_auto_install:
 	DESTDIR=$(CURDIR)/debian/tmp ninja -C ${BUILDDIR} install
 
-override_dh_gencontrol:
-	dh_gencontrol -- -v$(VERSION)~$(EYEPOP_PLATFORM)
-
 override_dh_install:
 ifeq ($(EYEPOP_PLATFORM),linux-aarch64-jammy)
 	dh_install --sourcedir=debian/tmp --list-missing --package=nnstreamer --package=nnstreamer-core --package=nnstreamer-configuration --package=nnstreamer-single --package=nnstreamer-tensorflow2-lite --package=nnstreamer-dev --package=nnstreamer-dev-internal --package=nnstreamer-single-dev --package=nnstreamer-single-dev-internal --package=nnstreamer-test-dev --package=nnstreamer-util --package=nnstreamer-misc --package=nnstreamer-datarepo

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -43,7 +43,7 @@ pipeline {
 
                         stage('Configure') {
                             steps {
-                                runShellCommand("sudo apt update && sudo apt install -y eyepop-tflite=3.0.0~linux-amd64-jammy-cuda eyepop-torchvision=3.0.0~linux-amd64-jammy-cuda")
+                                runShellCommand("sudo apt update && sudo apt install -y eyepop-tflite=3.0.0 eyepop-torchvision=3.0.0")
                                 runShellCommand("meson -Dwerror=false -Donnxruntime-support=enabled -Dtf-support=enabled -Dcaffe2-support=disabled -Dpython3-support=disabled build/ -Denable-test=false")
                             }
                         }
@@ -80,7 +80,7 @@ pipeline {
                             steps {
                                 withAWS(credentials:'repo-uploader', region: 'us-east-1') {
                                     script {
-                                        runShellCommand("deb-s3 upload --bucket repo.dev.eyepop.xyz ./build.debian/linux_amd64/*.deb")
+                                        runShellCommand("deb-s3 upload --preserve-versions --bucket repo.dev.eyepop.xyz ./build.debian/linux_amd64/*.deb")
                                     }
                                 }
                             }
@@ -119,7 +119,7 @@ pipeline {
 
                         stage('Configure') {
                             steps {
-                                runShellCommand("sudo apt update && sudo apt install -y eyepop-tflite=3.0.0~linux-aarch64-jammy libgtest-dev")
+                                runShellCommand("sudo apt update && sudo apt install -y eyepop-tflite=3.0.0 libgtest-dev")
                                 runShellCommand("meson -Dwerror=false -Donnxruntime-support=disabled -Dtf-support=disabled -Dcaffe2-support=disabled -Dpython3-support=disabled build/ -Denable-test=false")
                             }
                         }
@@ -156,7 +156,7 @@ pipeline {
                             steps {
                                 withAWS(credentials:'repo-uploader', region: 'us-east-1') {
                                     script {
-                                        runShellCommand("deb-s3 upload --bucket repo.dev.eyepop.xyz ./build.debian/linux_aarch64/*.deb")
+                                        runShellCommand("deb-s3 upload --preserve-versions --bucket repo.dev.eyepop.xyz ./build.debian/linux_aarch64/*.deb")
                                     }
                                 }
                             }

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -68,7 +68,7 @@ pipeline {
                             steps {
                                 runShellCommand('uname -a && mkdir -p ./build.debian/linux_amd64/')
                                 runShellCommand('DEB_BUILD_OPTIONS="nocheck notest" debuild -b -us -uc -Plinux-amd64-jammy')
-                                runShellCommand('mv ../nnstreamer*.deb ../nnstreamer*.ddeb ./build.debian/linux_amd64/ && ls -la ./build.debian/linux_amd64/')
+                                runShellCommand('mv ../nnstreamer*.deb ../nnstreamer*.ddeb ../nnstreamer*.build ../nnstreamer*.buildinfo ../nnstreamer*.changes ./build.debian/linux_amd64/ && ls -la ./build.debian/linux_amd64/')
                             }
                         }
                         stage('Debian publish') {
@@ -144,7 +144,7 @@ pipeline {
                             steps {
                                 runShellCommand('uname -a && mkdir -p ./build.debian/linux_aarch64/')
                                 runShellCommand('DEB_BUILD_OPTIONS="nocheck notest" debuild -b -us -uc -Plinux-aarch64-jammy')
-                                runShellCommand('mv ../nnstreamer*.deb ../nnstreamer*.ddeb ./build.debian/linux_aarch64/ && ls -la ./build.debian/linux_aarch64/')
+                                runShellCommand('mv ../nnstreamer*.deb ../nnstreamer*.ddeb ../nnstreamer*.build ../nnstreamer*.buildinfo ../nnstreamer*.changes ./build.debian/linux_aarch64/ && ls -la ./build.debian/linux_aarch64/')
                             }
                         }
                         stage('Debian publish') {


### PR DESCRIPTION
Changes:
* Remove platform ID from debian version
* Enabled version preservation on debian upload
* Update debian changelog timestamp in preparation for new 2.4.1-1.0.0 release