### PR TITLE
Enabled ONNX for aarch64, bumped ml-dev to 3.1.0

### DIFF
--- a/Documentation/getting-started-eyepop.md
+++ b/Documentation/getting-started-eyepop.md
@@ -36,7 +36,7 @@ sudo echo "deb [trusted=yes] http://repo.dev.eyepop.xyz.s3.us-east-1.amazonaws.c
 sudo apt install build-essential debhelper devscripts gcc9 meson ninja-build libglib2.0-dev \
      libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libjson-glib-dev gstreamer1.0-tools \
      gstreamer1.0-plugins-good libgtest-dev libopencv-dev flex bison python3-dev libpaho-mqtt-dev \
-     eyepop-tflite eyepop-torchvision
+     eyepop-onnxruntime eyepop-tflite eyepop-torchvision
 ```
 
 Build tools:

--- a/Documentation/getting-started-eyepop.md
+++ b/Documentation/getting-started-eyepop.md
@@ -64,6 +64,7 @@ Runtime dependencies:
 * `gstreamer1.0-plugins-good`
 
 EyePop-specific dependencies:
+* `eyepop-onnxruntime`
 * `eyepop-tflite`
 * `eyepop-torchvision` (amd64 only)
 
@@ -84,10 +85,10 @@ ninja -C build
 ninja -C build test
 ```
 
-To build/test for Ubuntu 22.04 on `aarch64` with support for TensorFlow Lite only:
+To build/test for Ubuntu 22.04 on `aarch64` with support for TensorFlow Lite and ONNX only:
 
 ```sh
-meson -Dwerror=false -Donnxruntime-support=disabled -Dtf-support=disabled -Dcaffe2-support=disabled -Dpython3-support=disabled build/ -Denable-test=false
+meson -Dwerror=false -Donnxruntime-support=enabled -Dtf-support=disabled -Dcaffe2-support=disabled -Dpython3-support=disabled build/ -Denable-test=false
 
 ninja -C build
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+nnstreamer (2.4.1-1.1.0) jammy; urgency=medium
+
+  * Enabled ONNX for aarch64
+  * Updated version of ml-dev to 3.1.0 (onnx, tensorflow[-cuda], tflite)
+
+ -- Tyler Stevens <tyler@eyepop.ai>  Thu, 17 Oct 2024 16:51:28 -0700
+
 nnstreamer (2.4.1-1.0.0) jammy; urgency=medium
 
   * Add support for aarch64 builds

--- a/debian/rules
+++ b/debian/rules
@@ -52,7 +52,7 @@ endif
 
 %:
 ifeq ($(EYEPOP_PLATFORM),linux-aarch64-jammy)
-	dh $@ --parallel --package=nnstreamer --package=nnstreamer-core --package=nnstreamer-configuration --package=nnstreamer-single --package=nnstreamer-tensorflow2-lite --package=nnstreamer-dev --package=nnstreamer-dev-internal --package=nnstreamer-single-dev --package=nnstreamer-single-dev-internal --package=nnstreamer-test-dev --package=nnstreamer-util --package=nnstreamer-misc --package=nnstreamer-datarepo
+	dh $@ --parallel --package=nnstreamer --package=nnstreamer-core --package=nnstreamer-configuration --package=nnstreamer-onnxruntime --package=nnstreamer-single --package=nnstreamer-tensorflow2-lite --package=nnstreamer-dev --package=nnstreamer-dev-internal --package=nnstreamer-single-dev --package=nnstreamer-single-dev-internal --package=nnstreamer-test-dev --package=nnstreamer-util --package=nnstreamer-misc --package=nnstreamer-datarepo
 else
 	dh $@ --parallel
 endif
@@ -66,7 +66,7 @@ ifeq ($(EYEPOP_PLATFORM),linux-aarch64-jammy)
 	meson --buildtype=plain --prefix=/usr --sysconfdir=/etc --libdir=lib/$(DEB_HOST_MULTIARCH) --bindir=lib/nnstreamer/bin --includedir=include \
 	-Denable-edgetpu=false -Denable-openvino=false -Dgrpc-support=disabled -Dmqtt-support=enabled \
 	-Ddatarepo-support=enabled \
-	-Dtf-support=disabled -Donnxruntime-support=disabled \
+	-Dtf-support=disabled -Donnxruntime-support=enabled \
 	-Denable-tizen=false -Denable-test=true -Dinstall-test=true -Dsubplugindir=/usr/lib/nnstreamer $(FLOAT16) ${BUILDDIR}
 else ifeq ($(shell dpkg-vendor --derives-from Ubuntu && echo yes), yes)
 	meson --buildtype=plain --prefix=/usr --sysconfdir=/etc --libdir=lib/$(DEB_HOST_MULTIARCH) --bindir=lib/nnstreamer/bin --includedir=include \
@@ -87,7 +87,6 @@ ifeq ($(EYEPOP_PLATFORM),linux-aarch64-jammy)
 	rm -f debian/nnstreamer-tensorflow.install
 	rm -f debian/nnstreamer-edgetpu.install
 	rm -f debian/nnstreamer-openvino.install
-	rm -f debian/nnstreamer-onnxruntime.install
 endif
 	# A few modules are not available in Ubuntu 22.04. Don't try to create them if not available.
 	if [ -f './build/ext/nnstreamer/tensor_filter/libnnstreamer_filter_nnfw.so' ]; then echo "NNFW exists" ; else rm -f debian/nnstreamer-nnfw.install; fi
@@ -112,7 +111,7 @@ override_dh_auto_install:
 
 override_dh_install:
 ifeq ($(EYEPOP_PLATFORM),linux-aarch64-jammy)
-	dh_install --sourcedir=debian/tmp --list-missing --package=nnstreamer --package=nnstreamer-core --package=nnstreamer-configuration --package=nnstreamer-single --package=nnstreamer-tensorflow2-lite --package=nnstreamer-dev --package=nnstreamer-dev-internal --package=nnstreamer-single-dev --package=nnstreamer-single-dev-internal --package=nnstreamer-test-dev --package=nnstreamer-util --package=nnstreamer-misc --package=nnstreamer-datarepo
+	dh_install --sourcedir=debian/tmp --list-missing --package=nnstreamer --package=nnstreamer-core --package=nnstreamer-configuration --package=nnstreamer-onnxruntime --package=nnstreamer-single --package=nnstreamer-tensorflow2-lite --package=nnstreamer-dev --package=nnstreamer-dev-internal --package=nnstreamer-single-dev --package=nnstreamer-single-dev-internal --package=nnstreamer-test-dev --package=nnstreamer-util --package=nnstreamer-misc --package=nnstreamer-datarepo
 else
 	dh_install --sourcedir=debian/tmp --list-missing
 endif

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
     parameters {
         booleanParam(name: 'ENABLE_DRY_RUN_COMPLETE', defaultValue: false, description: '"Runs" all stages (even conditional ones!) by printing out what would happen (ignores ENABLE_DEB_BUILD_WITHOUT_UPLOAD)')
         booleanParam(name: 'ENABLE_DEB_BUILD_WITHOUT_UPLOAD', defaultValue: false, description: 'Enable the debian build (without uploading!) for test purposes')
-        string(name: 'GIT_BRANCH', defaultValue: '*/main', description: 'The name of the branch to check out. Remember to change the Jenkins pipeline configuration\'s "Branches to build"!')
+        string(name: 'GIT_BRANCH', defaultValue: '*/main', description: 'The name of the branch to check out. May also be used in Jenkins pipeline configuration -- check before running!')
     }
 
     stages {
@@ -120,7 +120,7 @@ pipeline {
                         stage('Configure') {
                             steps {
                                 runShellCommand("sudo apt update && sudo apt install -y eyepop-onnxruntime=3.1.0 eyepop-tflite=3.1.0 libgtest-dev")
-                                runShellCommand("meson -Dwerror=false -Donnxruntime-support=disabled -Dtf-support=disabled -Dcaffe2-support=disabled -Dpython3-support=disabled build/ -Denable-test=false")
+                                runShellCommand("meson -Dwerror=false -Donnxruntime-support=enabled -Dtf-support=disabled -Dcaffe2-support=disabled -Dpython3-support=disabled build/ -Denable-test=false")
                             }
                         }
                     

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -43,7 +43,7 @@ pipeline {
 
                         stage('Configure') {
                             steps {
-                                runShellCommand("sudo apt update && sudo apt install -y eyepop-tflite=3.0.0 eyepop-torchvision=3.0.0")
+                                runShellCommand("sudo apt update && sudo apt install -y eyepop-onnxruntime=3.1.0 eyepop-tflite=3.1.0 eyepop-torchvision=3.1.0")
                                 runShellCommand("meson -Dwerror=false -Donnxruntime-support=enabled -Dtf-support=enabled -Dcaffe2-support=disabled -Dpython3-support=disabled build/ -Denable-test=false")
                             }
                         }
@@ -119,7 +119,7 @@ pipeline {
 
                         stage('Configure') {
                             steps {
-                                runShellCommand("sudo apt update && sudo apt install -y eyepop-tflite=3.0.0 libgtest-dev")
+                                runShellCommand("sudo apt update && sudo apt install -y eyepop-onnxruntime=3.1.0 eyepop-tflite=3.1.0 libgtest-dev")
                                 runShellCommand("meson -Dwerror=false -Donnxruntime-support=disabled -Dtf-support=disabled -Dcaffe2-support=disabled -Dpython3-support=disabled build/ -Denable-test=false")
                             }
                         }


### PR DESCRIPTION
Changes:
* Enabled ONNX for aarch64
* Updated `eyepop-ml-dev` version to 3.1.0
* Updated version number to 2.4.1-1.1.0